### PR TITLE
Fix question source code: Add missing semicolon

### DIFF
--- a/src/common/questions.tsx
+++ b/src/common/questions.tsx
@@ -162,7 +162,7 @@ Number.MIN_VALUE > 0; // ❓❓❓
 (1) === 1; // true
 Number.prototype.isOne = function () {
   return this === 1;
-}
+};
 (1).isOne(); // ❓❓❓
         `}
         />


### PR DESCRIPTION
The semicolon here is needed as the function (in its expression situation) would receive a "call attempt" by the following parenthesis without the semicolon.

I presume this is the correct behavior for the question, which prompts the user about the behavior of the `this` value inside primitive builtins — and not about an absent semicolon which, in this case, causes an error.

If, however, the question is indeed about the semicolon, we may have to change the correct answer to "Error" (it is currently "`false`" to reflect the behavior I mentioned above).